### PR TITLE
VXQUERY-184: fixed the order by translator

### DIFF
--- a/vxquery-core/src/main/java/org/apache/vxquery/datamodel/accessors/jsonItem/ArrayPointable.java
+++ b/vxquery-core/src/main/java/org/apache/vxquery/datamodel/accessors/jsonItem/ArrayPointable.java
@@ -1,0 +1,59 @@
+package org.apache.vxquery.datamodel.accessors.jsonItem;
+
+import org.apache.hyracks.api.dataflow.value.ITypeTraits;
+import org.apache.hyracks.data.std.api.IPointable;
+import org.apache.hyracks.data.std.api.IPointableFactory;
+import org.apache.hyracks.data.std.primitive.IntegerPointable;
+import org.apache.hyracks.data.std.primitive.VoidPointable;
+import org.apache.vxquery.datamodel.accessors.SequencePointable;
+
+public class ArrayPointable extends SequencePointable {
+    private static final int ENTRY_COUNT_SIZE = 4;
+    private static final int SLOT_SIZE = 4;
+    public static final IPointableFactory FACTORY = new IPointableFactory() {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public ITypeTraits getTypeTraits() {
+            return VoidPointable.TYPE_TRAITS;
+        }
+
+        @Override
+        public IPointable createPointable() {
+            return new ArrayPointable();
+        }
+    };
+
+    public int getEntryCount() {
+        return getEntryCount(bytes, start);
+    }
+
+    private static int getEntryCount(byte[] bytes, int start) {
+        return IntegerPointable.getInteger(bytes, start);
+    }
+
+    public void getEntry(int idx, IPointable pointer) {
+        int dataStart = getDataStart(bytes, start);
+        pointer.set(bytes, dataStart + getRelativeEntryStartOffset(idx), getEntryLength(idx));
+    }
+
+    private static int getEntryOffsetValue(byte[] bytes, int start, int idx) {
+        return IntegerPointable.getInteger(bytes, getOffsetsStart(start) + idx * SLOT_SIZE);
+    }
+
+    private int getRelativeEntryStartOffset(int idx) {
+        return idx == 0 ? 0 : getEntryOffsetValue(bytes, start, idx - 1);
+    }
+
+    private int getEntryLength(int idx) {
+        return getEntryOffsetValue(bytes, start, idx) - getRelativeEntryStartOffset(idx);
+    }
+
+    private static int getOffsetsStart(int start) {
+        return start + ENTRY_COUNT_SIZE;
+    }
+
+    private static int getDataStart(byte[] bytes, int start) {
+        return getOffsetsStart(start) + getEntryCount(bytes, start) * SLOT_SIZE;
+    }
+}

--- a/vxquery-core/src/main/java/org/apache/vxquery/datamodel/builders/jsonItem/ArrayBuilder.java
+++ b/vxquery-core/src/main/java/org/apache/vxquery/datamodel/builders/jsonItem/ArrayBuilder.java
@@ -1,0 +1,33 @@
+package org.apache.vxquery.datamodel.builders.jsonItem;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.hyracks.data.std.api.IMutableValueStorage;
+import org.apache.hyracks.data.std.util.ArrayBackedValueStorage;
+import org.apache.vxquery.datamodel.builders.sequence.SequenceBuilder;
+import org.apache.vxquery.datamodel.values.ValueTag;
+import org.apache.vxquery.util.GrowableIntArray;
+
+public class ArrayBuilder extends SequenceBuilder {
+    private final GrowableIntArray slots = new GrowableIntArray();
+    private final ArrayBackedValueStorage dataArea = new ArrayBackedValueStorage();
+    private IMutableValueStorage mvs;
+
+    public ArrayBuilder() {
+    }
+
+    public void finish() throws IOException {
+        DataOutput out = mvs.getDataOutput();
+        out.write(ValueTag.ARRAY_TAG);
+        int size = slots.getSize();
+        out.writeInt(size);
+        if (size > 0) {
+            int[] slotArray = slots.getArray();
+            for (int i = 0; i < size; ++i) {
+                out.writeInt(slotArray[i]);
+            }
+            out.write(dataArea.getByteArray(), dataArea.getStartOffset(), dataArea.getLength());
+        }
+    }
+}

--- a/vxquery-core/src/main/java/org/apache/vxquery/xmlquery/translator/XMLQueryTranslator.java
+++ b/vxquery-core/src/main/java/org/apache/vxquery/xmlquery/translator/XMLQueryTranslator.java
@@ -1076,7 +1076,8 @@ public class XMLQueryTranslator {
                     List<org.apache.hyracks.algebricks.common.utils.Pair<OrderOperator.IOrder, Mutable<ILogicalExpression>>> oExprs = new ArrayList<org.apache.hyracks.algebricks.common.utils.Pair<OrderOperator.IOrder, Mutable<ILogicalExpression>>>();
                     List<String> collations = new ArrayList<String>();
                     for (OrderSpecNode osNode : ocNode.getOrderSpec()) {
-                        ILogicalExpression oExpr = vre(translateExpression(osNode.getExpression(), tCtx));
+                        ILogicalExpression aExpr = data(vre(translateExpression(osNode.getExpression(), tCtx)));
+                        ILogicalExpression oExpr = vre(createAssignment(aExpr, tCtx));
                         OrderOperator.IOrder o = OrderOperator.ASC_ORDER;
                         XQueryConstants.OrderDirection oDir = osNode.getDirection();
                         if (oDir != null) {


### PR DESCRIPTION
We updated the order by clause to use the atomic values for sorting
