### PR TITLE
Solved: Issue with "compileonly" flag while executing queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .project
 .settings
 .classpath
+.idea
 target
 /ClusterControllerService/

--- a/vxquery-cli/src/main/java/org/apache/vxquery/cli/VXQuery.java
+++ b/vxquery-cli/src/main/java/org/apache/vxquery/cli/VXQuery.java
@@ -248,7 +248,7 @@ public class VXQuery {
             }
             return nodeList;
         }
-        return new String[0];
+        return null;
     }
 
     /**

--- a/vxquery-cli/src/main/java/org/apache/vxquery/cli/VXQuery.java
+++ b/vxquery-cli/src/main/java/org/apache/vxquery/cli/VXQuery.java
@@ -240,13 +240,16 @@ public class VXQuery {
      * @throws Exception
      */
     private String[] getNodeList() throws Exception {
-        Map<String, NodeControllerInfo> nodeControllerInfos = hcc.getNodeControllerInfos();
-        String[] nodeList = new String[nodeControllerInfos.size()];
-        int index = 0;
-        for (String node : nodeControllerInfos.keySet()) {
-            nodeList[index++] = node;
+        if(hcc != null) {
+            Map<String, NodeControllerInfo> nodeControllerInfos = hcc.getNodeControllerInfos();
+            String[] nodeList = new String[nodeControllerInfos.size()];
+            int index = 0;
+            for (String node : nodeControllerInfos.keySet()) {
+                nodeList[index++] = node;
+            }
+            return nodeList;
         }
-        return nodeList;
+        return new String[0];
     }
 
     /**

--- a/vxquery-cli/src/main/java/org/apache/vxquery/cli/VXQuery.java
+++ b/vxquery-cli/src/main/java/org/apache/vxquery/cli/VXQuery.java
@@ -81,8 +81,7 @@ public class VXQuery {
     /**
      * Constructor to use command line options passed.
      *
-     * @param opts
-     *            Command line options object
+     * @param opts Command line options object
      */
     public VXQuery(CmdLineOptions opts) {
         this.opts = opts;
@@ -240,7 +239,7 @@ public class VXQuery {
      * @throws Exception
      */
     private String[] getNodeList() throws Exception {
-        if(hcc != null) {
+        if (hcc != null) {
             Map<String, NodeControllerInfo> nodeControllerInfos = hcc.getNodeControllerInfos();
             String[] nodeList = new String[nodeControllerInfos.size()];
             int index = 0;
@@ -256,10 +255,8 @@ public class VXQuery {
      * Creates a Hyracks dataset, if not already existing with the job frame size, and 1 reader. Allocates a new buffer of size specified in the frame of Hyracks
      * node. Creates new dataset reader with the current job ID and result set ID. Outputs the string in buffer for each frame.
      *
-     * @param spec
-     *            JobSpecification object, containing frame size. Current specified job.
-     * @param writer
-     *            Writer for output of job.
+     * @param spec   JobSpecification object, containing frame size. Current specified job.
+     * @param writer Writer for output of job.
      * @throws Exception
      */
     private void runJob(JobSpecification spec, PrintWriter writer) throws Exception {
@@ -342,8 +339,7 @@ public class VXQuery {
     /**
      * Reads the contents of file given in query into a String. The file is always closed. For XML files UTF-8 encoding is used.
      *
-     * @param query
-     *            The query with filename to be processed
+     * @param query The query with filename to be processed
      * @return UTF-8 formatted query string
      * @throws IOException
      */
@@ -365,7 +361,8 @@ public class VXQuery {
      * Helper class with fields and methods to handle all command line options
      */
     private static class CmdLineOptions {
-        @Option(name = "-available-processors", usage = "Number of available processors. (default: java's available processors)")
+        @Option(name = "-available-processors",
+                usage = "Number of available processors. (default: java's available processors)")
         private int availableProcessors = -1;
 
         @Option(name = "-client-net-ip-address", usage = "IP Address of the ClusterController.")

--- a/vxquery-core/src/main/java/org/apache/vxquery/metadata/VXQueryMetadataProvider.java
+++ b/vxquery-core/src/main/java/org/apache/vxquery/metadata/VXQueryMetadataProvider.java
@@ -111,9 +111,11 @@ public class VXQueryMetadataProvider implements IMetadataProvider<String, String
 
     public static AlgebricksPartitionConstraint getClusterLocations(String[] nodeList, int partitions) {
         ArrayList<String> locs = new ArrayList<String>();
-        for (String node : nodeList) {
-            for (int j = 0; j < partitions; j++) {
-                locs.add(node);
+        if (nodeList != null) {
+            for (String node : nodeList) {
+                for (int j = 0; j < partitions; j++) {
+                    locs.add(node);
+                }
             }
         }
         String[] cluster = new String[locs.size()];


### PR DESCRIPTION
Issue No. : VXQUERY-139
Description : Previously executing queries with compileonly flag
gave NPE, which was due to null value of IHyracksClientConnection.

Solver : @ankitladhania
