### PR TITLE
VXQUERY-25: Fixes the file issue with running JUNIT through maven

### DIFF
--- a/vxquery-xtest/pom.xml
+++ b/vxquery-xtest/pom.xml
@@ -14,7 +14,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -109,15 +110,28 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                     <!-- <argLine>-agentpath:"${yourkit.home}/bin/mac/libyjpagent.jnilib=sampling"</argLine> -->
+                    <!-- <argLine>-agentpath:"${yourkit.home}/bin/mac/libyjpagent.jnilib=sampling"</argLine> -->
                     <excludes>
                         <exclude>**/AbstractXQueryTest.java</exclude>
+                        <exclude>**/VXQueryCheckXQTSTest.java</exclude>
                         <exclude>**/VXQueryXMarkTest.java</exclude>
                         <exclude>**/XMarkTest.java</exclude>
                         <exclude>**/XQTSTest.java</exclude>
-                        <exclude>**/VXQueryCheckXQTSTest.java</exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/vxquery-xtest/src/main/java/org/apache/vxquery/xtest/TestClusterUtil.java
+++ b/vxquery-xtest/src/main/java/org/apache/vxquery/xtest/TestClusterUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.vxquery.xtest;
 
+import org.apache.hyracks.api.client.HyracksConnection;
+import org.apache.hyracks.client.dataset.HyracksDataset;
 import org.apache.hyracks.control.cc.ClusterControllerService;
 import org.apache.hyracks.control.common.controllers.CCConfig;
 import org.apache.hyracks.control.common.controllers.NCConfig;
@@ -29,12 +31,15 @@ import java.net.UnknownHostException;
 
 public class TestClusterUtil {
 
-    private static int clientNetPort = 39000;
-    private static int clusterNetPort = 39001;
-    private static int profileDumpPeriod = 10000;
-    private static String ccHost = "localhost";
-    private static String nodeId = "nc1";
-    private static String ioDevices = "target/tmp/indexFolder";
+    private static final int CLIENT_NET_PORT = 39000;
+    private static final int CLUSTER_NET_PORT = 39001;
+    private static final int PROFILE_DUMP_PERIOD = 10000;
+    private static final String CC_HOST = "localhost";
+    private static final String NODE_ID = "nc1";
+    private static final String IO_DEVICES = "target/tmp/indexFolder";
+
+    private static HyracksConnection hcc;
+    private static HyracksDataset hds;
 
     private TestClusterUtil() {
     }
@@ -43,27 +48,27 @@ public class TestClusterUtil {
         String publicAddress = InetAddress.getLocalHost().getHostAddress();
         CCConfig ccConfig = new CCConfig();
         ccConfig.clientNetIpAddress = publicAddress;
-        ccConfig.clientNetPort = clientNetPort;
+        ccConfig.clientNetPort = CLIENT_NET_PORT;
         ccConfig.clusterNetIpAddress = publicAddress;
-        ccConfig.clusterNetPort = clusterNetPort;
-        ccConfig.profileDumpPeriod = profileDumpPeriod;
+        ccConfig.clusterNetPort = CLUSTER_NET_PORT;
+        ccConfig.profileDumpPeriod = PROFILE_DUMP_PERIOD;
         return ccConfig;
     }
 
     public static NCConfig createNCConfig() throws UnknownHostException {
         String publicAddress = InetAddress.getLocalHost().getHostAddress();
         NCConfig ncConfig1 = new NCConfig();
-        ncConfig1.ccHost = ccHost;
-        ncConfig1.ccPort = clusterNetPort;
+        ncConfig1.ccHost = CC_HOST;
+        ncConfig1.ccPort = CLUSTER_NET_PORT;
         ncConfig1.clusterNetIPAddress = publicAddress;
         ncConfig1.dataIPAddress = publicAddress;
         ncConfig1.resultIPAddress = publicAddress;
-        ncConfig1.nodeId = nodeId;
-        ncConfig1.ioDevices = ioDevices;
+        ncConfig1.nodeId = NODE_ID;
+        ncConfig1.ioDevices = IO_DEVICES;
         return ncConfig1;
     }
 
-    public static ClusterControllerService startCC() throws IOException {
+    public static ClusterControllerService startCC(XTestOptions opts) throws IOException {
         CCConfig ccConfig = createCCConfig();
         File outDir = new File("target/ClusterController");
         outDir.mkdirs();
@@ -74,6 +79,8 @@ public class TestClusterUtil {
         try {
             ClusterControllerService cc = new ClusterControllerService(ccConfig);
             cc.start();
+            hcc = new HyracksConnection(ccConfig.clientNetIpAddress, ccConfig.clientNetPort);
+            hds = new HyracksDataset(hcc, opts.frameSize, opts.threads);
             return cc;
         } catch (Exception e) {
             throw new IOException(e);
@@ -90,6 +97,14 @@ public class TestClusterUtil {
         } catch (Exception e) {
             throw new IOException(e);
         }
+    }
+
+    public static HyracksConnection getConnection() {
+        return hcc;
+    }
+
+    public static HyracksDataset getDataset() {
+        return hds;
     }
 
     public static void stopCluster(ClusterControllerService cc, NodeControllerService nc) throws IOException {

--- a/vxquery-xtest/src/main/java/org/apache/vxquery/xtest/TestRunner.java
+++ b/vxquery-xtest/src/main/java/org/apache/vxquery/xtest/TestRunner.java
@@ -24,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.hyracks.api.client.HyracksConnection;
 import org.apache.hyracks.api.client.IHyracksClientConnection;
 import org.apache.hyracks.api.client.NodeControllerInfo;
 import org.apache.hyracks.api.comm.IFrame;
@@ -38,7 +37,6 @@ import org.apache.hyracks.api.job.JobFlag;
 import org.apache.hyracks.api.job.JobId;
 import org.apache.hyracks.api.job.JobSpecification;
 import org.apache.hyracks.client.dataset.HyracksDataset;
-import org.apache.hyracks.control.common.controllers.CCConfig;
 import org.apache.hyracks.control.nc.resources.memory.FrameManager;
 import org.apache.hyracks.dataflow.common.comm.io.ResultFrameTupleAccessor;
 import org.apache.vxquery.compiler.CompilerControlBlock;
@@ -66,8 +64,8 @@ public class TestRunner {
     }
 
     public void open() throws Exception {
-        CCConfig ccConfig = TestClusterUtil.createCCConfig();
-        hcc = new HyracksConnection(ccConfig.clientNetIpAddress, ccConfig.clientNetPort);
+        hcc = TestClusterUtil.getConnection();
+        hds = TestClusterUtil.getDataset();
     }
 
     public TestCaseResult run(final TestCase testCase) {
@@ -111,9 +109,6 @@ public class TestRunner {
                 spec.setMaxReattempts(0);
                 JobId jobId = hcc.startJob(spec, EnumSet.of(JobFlag.PROFILE_RUNTIME));
 
-                if (hds == null) {
-                    hds = new HyracksDataset(hcc, spec.getFrameSize(), opts.threads);
-                }
                 FrameManager resultDisplayFrameMgr = new FrameManager(spec.getFrameSize());
                 IFrame frame = new VSizeFrame(resultDisplayFrameMgr);
                 IHyracksDatasetReader reader = hds.createReader(jobId, ccb.getResultSetId());

--- a/vxquery-xtest/src/main/java/org/apache/vxquery/xtest/XTest.java
+++ b/vxquery-xtest/src/main/java/org/apache/vxquery/xtest/XTest.java
@@ -81,7 +81,7 @@ public class XTest {
                 }
             }
         });
-        cc = TestClusterUtil.startCC();
+        cc = TestClusterUtil.startCC(opts);
         nc = TestClusterUtil.startNC();
         trf = new TestRunnerFactory(opts);
         trf.registerReporters(reporters);

--- a/vxquery-xtest/src/test/java/org/apache/vxquery/xtest/AbstractXQueryTest.java
+++ b/vxquery-xtest/src/test/java/org/apache/vxquery/xtest/AbstractXQueryTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractXQueryTest {
 
     @BeforeClass
     public static void setup() throws IOException {
-        cc = TestClusterUtil.startCC();
+        cc = TestClusterUtil.startCC(getDefaultTestOptions());
         nc = TestClusterUtil.startNC();
         setupFS();
     }

--- a/vxquery-xtest/src/test/java/org/apache/vxquery/xtest/VXQueryIT.java
+++ b/vxquery-xtest/src/test/java/org/apache/vxquery/xtest/VXQueryIT.java
@@ -25,16 +25,16 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class VXQueryCheckXQTSTest extends AbstractXQueryTest {
+public class VXQueryIT extends AbstractXQueryTest {
 
     private static String XQTS_CATALOG = StringUtils.join(new String[] { "test-suites", "xqts", "XQTSCatalog.xml" },
             File.separator);
 
-    public VXQueryCheckXQTSTest(TestCase tc) throws Exception {
+    public VXQueryIT(TestCase tc) throws Exception {
         super(tc);
     }
 
-    @Parameters(name = "VXQueryCheckXQTSTest {index}: {0}")
+    @Parameters(name = "VXQueryIT {index}: {0}")
     public static Collection<Object[]> tests() throws Exception {
         JUnitTestCaseFactory jtcf_vxquery = new JUnitTestCaseFactory(getOptions());
         Collection<Object[]> tests = jtcf_vxquery.getList();


### PR DESCRIPTION
Maven will now be able to run the XQTS JUNIT test without opening
to many files. If XQTS is installed locally then the system will run
these tests during verify and/or integration-tests.

The fix involves only creating one cluster instance, one connection, and
one dataset. These instances are reused for each test.
