### PR TITLE
POM Dependency Clean Up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -164,13 +162,13 @@
             <timezone>+3</timezone>
         </contributor>
         <contributor>
-            <name>Shivani Mall</name>
+            <name>Erandi Ganepola</name>
             <email />
             <organization />
             <roles>
                 <role>Developer</role>
             </roles>
-            <timezone>-8</timezone>
+            <timezone>+5:30</timezone>
         </contributor>
         <contributor>
             <name>Menaka Madushanka</name>
@@ -189,6 +187,15 @@
                 <role>Developer</role>
             </roles>
             <timezone>+5:30</timezone>
+        </contributor>
+        <contributor>
+            <name>Shivani Mall</name>
+            <email />
+            <organization />
+            <roles>
+                <role>Developer</role>
+            </roles>
+            <timezone>-8</timezone>
         </contributor>
     </contributors>
 
@@ -220,39 +227,71 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>ant</groupId>
+                <artifactId>ant-trax</artifactId>
+                <version>1.6.5</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>args4j</groupId>
                 <artifactId>args4j</artifactId>
                 <version>2.0.9</version>
             </dependency>
 
             <dependency>
-                <groupId>org.apache.hyracks</groupId>
-                <artifactId>hyracks-client</artifactId>
-                <version>${hyracks.version}</version>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.8.4</version>
             </dependency>
 
             <dependency>
-                <groupId>org.apache.hyracks</groupId>
-                <artifactId>hyracks-control-common</artifactId>
-                <version>${hyracks.version}</version>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>11.0.2</version>
             </dependency>
 
             <dependency>
-                <groupId>org.apache.hyracks</groupId>
-                <artifactId>hyracks-control-cc</artifactId>
-                <version>${hyracks.version}</version>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>1.3.1</version>
             </dependency>
 
             <dependency>
-                <groupId>org.apache.hyracks</groupId>
-                <artifactId>hyracks-control-nc</artifactId>
-                <version>${hyracks.version}</version>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.4</version>
             </dependency>
 
             <dependency>
-                <groupId>org.apache.hyracks</groupId>
-                <artifactId>hyracks-http</artifactId>
-                <version>${hyracks.fullstack.version}</version>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
+            </dependency>
+
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.2.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.11</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -260,17 +299,53 @@
                 <artifactId>netty-all</artifactId>
                 <version>4.1.6.Final</version>
             </dependency>
-            
-            <dependency>
-                <groupId>org.apache.hyracks</groupId>
-                <artifactId>algebricks-compiler</artifactId>
-                <version>${hyracks.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-hdfs</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-mapreduce-client-core</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.htrace</groupId>
+                <artifactId>htrace-core</artifactId>
+                <version>3.1.0-incubating</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hyracks</groupId>
+                <artifactId>algebricks-compiler</artifactId>
+                <version>${hyracks.version}</version>
             </dependency>
 
             <dependency>
@@ -311,6 +386,30 @@
 
             <dependency>
                 <groupId>org.apache.hyracks</groupId>
+                <artifactId>hyracks-client</artifactId>
+                <version>${hyracks.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hyracks</groupId>
+                <artifactId>hyracks-control-cc</artifactId>
+                <version>${hyracks.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hyracks</groupId>
+                <artifactId>hyracks-control-common</artifactId>
+                <version>${hyracks.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hyracks</groupId>
+                <artifactId>hyracks-control-nc</artifactId>
+                <version>${hyracks.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hyracks</groupId>
                 <artifactId>hyracks-data-std</artifactId>
                 <version>${hyracks.version}</version>
             </dependency>
@@ -329,8 +428,20 @@
 
             <dependency>
                 <groupId>org.apache.hyracks</groupId>
+                <artifactId>hyracks-http</artifactId>
+                <version>${hyracks.fullstack.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hyracks</groupId>
                 <artifactId>hyracks-hdfs-2.x</artifactId>
                 <version>${hyracks.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish</groupId>
+                        <artifactId>javax.servlet</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -341,77 +452,39 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-hdfs</artifactId>
-                <version>2.7.0</version>
+                <groupId>org.apache.hyracks</groupId>
+                <artifactId>hyracks-util</artifactId>
+                <version>${hyracks.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>ant</groupId>
-                <artifactId>ant-trax</artifactId>
-                <version>1.6.5</version>
-                <scope>provided</scope>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>${lucene.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.codehaus.woodstox</groupId>
-                <artifactId>stax2-api</artifactId>
-                <version>3.0.1</version>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${lucene.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.codehaus.woodstox</groupId>
-                <artifactId>woodstox-core-asl</artifactId>
-                <version>4.0.6</version>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers-common</artifactId>
+                <version>${lucene.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>xalan</groupId>
-                <artifactId>serializer</artifactId>
-                <version>2.7.1</version>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>1.9.13</version>
             </dependency>
 
             <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xercesImpl</artifactId>
-                <version>2.9.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>activemq</groupId>
-                <artifactId>activemq-transport-xstream</artifactId>
-                <version>2.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.thoughtworks.xstream</groupId>
-                <artifactId>xstream</artifactId>
-                <version>1.3.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>2.8.4</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.4</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.4</version>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.11</version>
-                <scope>test</scope>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20090211</version>
             </dependency>
 
             <dependency>
@@ -419,6 +492,12 @@
                 <artifactId>jetty</artifactId>
                 <version>6.1.22</version>
                 <scope>compile</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.3.04</version>
             </dependency>
 
         </dependencies>
@@ -682,9 +761,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <hyracks.version>0.2.17-incubating</hyracks.version>
         <hyracks.fullstack.version>0.3.1</hyracks.fullstack.version>
         <hyracks.version>0.3.0</hyracks.version>
+        <lucene.version>5.5.1</lucene.version>
+        <hadoop.version>2.7.0</hadoop.version>
         <apache-rat-plugin.version>0.11</apache-rat-plugin.version>
     </properties>
 

--- a/vxquery-cli/pom.xml
+++ b/vxquery-cli/pom.xml
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -75,6 +75,31 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.vxquery</groupId>
             <artifactId>apache-vxquery-rest</artifactId>

--- a/vxquery-core/pom.xml
+++ b/vxquery-core/pom.xml
@@ -14,7 +14,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -171,8 +172,89 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>algebricks-core</artifactId>
         </dependency>
 
         <dependency>
@@ -182,12 +264,22 @@
 
         <dependency>
             <groupId>org.apache.hyracks</groupId>
-            <artifactId>algebricks-rewriter</artifactId>
+            <artifactId>algebricks-common</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hyracks</groupId>
             <artifactId>algebricks-data</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>algebricks-rewriter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>algebricks-runtime</artifactId>
         </dependency>
 
         <dependency>
@@ -221,112 +313,13 @@
         </dependency>
 
         <dependency>
-            <groupId>ant</groupId>
-            <artifactId>ant-trax</artifactId>
-            <scope>provided</scope>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-util</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>stax2-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>serializer</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>activemq</groupId>
-            <artifactId>activemq-transport-xstream</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <artifactId>lucene-core</artifactId>
-            <groupId>org.apache.lucene</groupId>
-            <type>jar</type>
-            <version>5.5.1</version>
-        </dependency>
-
-        <dependency>
-            <artifactId>lucene-queryparser</artifactId>
-            <groupId>org.apache.lucene</groupId>
-            <type>jar</type>
-            <version>5.5.1</version>
-        </dependency>
-
-        <dependency>
-            <artifactId>lucene-analyzers-common</artifactId>
-            <groupId>org.apache.lucene</groupId>
-            <type>jar</type>
-            <version>5.5.1</version>
-        </dependency>
-
-        <dependency>
-            <artifactId>lucene-demo</artifactId>
-            <groupId>org.apache.lucene</groupId>
-            <type>jar</type>
-            <version>5.5.1</version>
-        </dependency>
-
-        <dependency>
-            <artifactId>lucene-backward-codecs</artifactId>
-            <groupId>org.apache.lucene</groupId>
-            <type>jar</type>
-            <version>5.5.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <version>2.7.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>2.7.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs</artifactId>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
         </dependency>
 
     </dependencies>

--- a/vxquery-rest/pom.xml
+++ b/vxquery-rest/pom.xml
@@ -16,9 +16,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>apache-vxquery</artifactId>
         <groupId>org.apache.vxquery</groupId>
@@ -34,23 +33,107 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.vxquery</groupId>
-            <artifactId>apache-vxquery-core</artifactId>
-            <version>0.7-SNAPSHOT</version>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-client</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-http</artifactId>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>algebricks-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>algebricks-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-control-cc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-control-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-control-nc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-dataflow-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-http</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.vxquery</groupId>
+            <artifactId>apache-vxquery-core</artifactId>
+            <version>0.7-SNAPSHOT</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/vxquery-rest/src/main/java/org/apache/vxquery/app/util/LocalClusterUtil.java
+++ b/vxquery-rest/src/main/java/org/apache/vxquery/app/util/LocalClusterUtil.java
@@ -57,12 +57,11 @@ public class LocalClusterUtil {
     public static final int DEFAULT_HYRACKS_CC_HTTP_PORT = 39002;
     public static final int DEFAULT_VXQUERY_REST_PORT = 39003;
 
-    // TODO review variable scope after XTest is updated to use the REST service.
-    public ClusterControllerService clusterControllerService;
-    public NodeControllerService nodeControllerSerivce;
-    public IHyracksClientConnection hcc;
-    public IHyracksDataset hds;
-    public VXQueryService vxQueryService;
+    private ClusterControllerService clusterControllerService;
+    private NodeControllerService nodeControllerSerivce;
+    private IHyracksClientConnection hcc;
+    private IHyracksDataset hds;
+    private VXQueryService vxQueryService;
 
     public void init(VXQueryConfig config) throws Exception {
         // Following properties are needed by the app to setup

--- a/vxquery-rest/src/test/java/org/apache/vxquery/rest/AbstractRestServerTest.java
+++ b/vxquery-rest/src/test/java/org/apache/vxquery/rest/AbstractRestServerTest.java
@@ -55,7 +55,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
  *
  * @author Erandi Ganepola
  */
-public class AbstractRestServerTest {
+public abstract class AbstractRestServerTest {
 
     protected static LocalClusterUtil vxqueryLocalCluster = new LocalClusterUtil();
     protected static String restIpAddress;
@@ -161,11 +161,11 @@ public class AbstractRestServerTest {
      *            {@link QueryResultRequest}
      * @param accepts
      *            expected
-     * 
+     *
      *            <pre>
      *            Accepts
      *            </pre>
-     * 
+     *
      *            header in responses
      * @param method
      *            Http Method to be used to send the request

--- a/vxquery-server/pom.xml
+++ b/vxquery-server/pom.xml
@@ -14,7 +14,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -142,17 +143,19 @@
 
     <dependencies>
         <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hyracks</groupId>
+            <artifactId>hyracks-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.vxquery</groupId>
             <artifactId>apache-vxquery-rest</artifactId>
             <version>0.7-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-control-cc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-control-nc</artifactId>
         </dependency>
     </dependencies>
 

--- a/vxquery-xtest/pom.xml
+++ b/vxquery-xtest/pom.xml
@@ -138,15 +138,68 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.vxquery</groupId>
-            <artifactId>apache-vxquery-core</artifactId>
-            <version>0.7-SNAPSHOT</version>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.vxquery</groupId>
-            <artifactId>apache-vxquery-rest</artifactId>
-            <version>0.7-SNAPSHOT</version>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <classifier>tests</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+            <classifier>tests</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
         </dependency>
 
         <dependency>
@@ -160,59 +213,30 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-control-cc</artifactId>
+            <groupId>org.apache.vxquery</groupId>
+            <artifactId>apache-vxquery-core</artifactId>
+            <version>0.7-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-control-nc</artifactId>
+            <groupId>org.apache.vxquery</groupId>
+            <artifactId>apache-vxquery-rest</artifactId>
+            <version>0.7-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-dataflow-std</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hyracks</groupId>
-            <artifactId>hyracks-hdfs-2.x</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs</artifactId>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>2.7.0</version>
-            <classifier>tests</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs</artifactId>
-            <version>2.7.0</version>
-            <classifier>tests</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
 - updated based on results from: "mvn dependency:analyze"
 - Minor item from GSOC commit.
 - Ordered dependencies to improve maintenance.

This is my attempt to bring the changes in https://github.com/apache/vxquery/pull/162 into master. Something went wrong in the REST project and now the tests fail due to a missing class. Any ideas?